### PR TITLE
Remove outdated content from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,5 @@
 # NLP(Natural Language Processing) Note
 
-## New Content: Non-Neurotransmitter Based Reinforcement Learning
-
-🧠 **[Non-Neurotransmitter Reinforcement Learning](non-neurotransmitter-reinforcement-learning.md)** - Comprehensive exploration of RL approaches that don't rely on traditional neurotransmitter mechanisms.
-
-🐍 **[Python Implementations](non_neurotransmitter_rl_implementations.py)** - Practical implementations of biological and engineering non-neurotransmitter RL methods.
-
-🧪 **[Test Suite](test_non_neurotransmitter_rl.py)** - Comprehensive test cases validating all implementations.
-
-**Key Features:**
-- **Biological Mechanisms**: Stress-adaptive learning (cortisol), social learning (oxytocin), LTP-based learning
-- **Engineering Methods**: Free energy principle, maximum entropy RL, evolutionary strategies
-- **Comparative Analysis**: Statistical comparison framework with performance metrics
-- **Research Applications**: Biomedical modeling, optimization, multi-agent systems
-- **Theoretical Framework**: Information theory, Bayesian learning, dynamical systems perspectives
-
-## Mathematical Finance for Risk Management
-
-📊 **[Mathematical Finance Risk Management](mathematical-finance-risk-management.md)** - Learn how to apply mathematical finance techniques for non-monetary risk assessment and management.
-
-📈 **[Python Examples](mathematical_finance_risk_examples.py)** - Practical implementations of VaR, CVaR, portfolio optimization, Monte Carlo simulations, and more.
-
-**Key Features:**
-- Value at Risk (VaR) and Conditional VaR for any type of loss measurement
-- Portfolio optimization for resource allocation
-- Monte Carlo simulation for scenario analysis
-- Risk-adjusted performance metrics (Sharpe ratio, maximum drawdown)
-- Project timeline risk assessment
-- Non-monetary applications of financial risk models
-
 # Same old same old
 
 American Humor. We are just kidding.


### PR DESCRIPTION
Removed sections on Non-Neurotransmitter Based Reinforcement Learning and Mathematical Finance for Risk Management from the README.